### PR TITLE
comma removed

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -106,6 +106,6 @@
       "name": "Airflow",
       "url": "https://github.com/apache/airflow",
       "ourLatest": "2.9.2"
-    },
+    }
   ]
 }


### PR DESCRIPTION
 remove trailing comma in json for python parsing, otherwise, windmill flow (get_latest_release_and_post_to_mm ) fails
 https://windmill.dev.hyperplane.dev/run/0190691f-a571-7bf0-0836-9f926534a838?workspace=shakudo