### PR TITLE
Updating milvus attu image version to 2.4.3

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -57,7 +57,8 @@
     },
     {
       "name": "Milvus",
-      "url": "https://github.com/milvus-io/milvus"
+      "url": "https://github.com/milvus-io/milvus",
+      "ourLatest": "2.4.3"
     },
     {
       "name": "Superset",


### PR DESCRIPTION
Update milvus attu version to 2.4.3. 
Related to https://github.com/devsentient/monorepo/issues/6866