### PR TITLE
Update MLflow version stack-component-versions

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -80,7 +80,7 @@
     {
       "name": "MLflow",
       "url": "https://github.com/mlflow/mlflow",
-      "ourLatest": "2.8.0"
+      "ourLatest": "2.15.1"
     },
     {
       "name": "ActivePieces",


### PR DESCRIPTION
Update MLflow version to 2.15.1 in stack-component-versions