### PR TITLE
add dremio version

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -336,6 +336,11 @@
       "name": "langflow-runtime",
       "url": "https://github.com/langflow-ai/langflow",
       "ourLatest": "1.0.14"
+    },
+    {
+      "name": "Dremio",
+      "url": "https://github.com/dremio/dremio-cloud-tools",
+      "ourLatest": "25.0.0"
     }
   ]
 }


### PR DESCRIPTION
Added Dremio github repo and version 

"name": "Dremio",      
"url": "https://github.com/dremio/dremio-cloud-tools",
"ourLatest": "25.0.0"