### PR TITLE
Downgrade Dremio to 20.1.0

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -350,7 +350,7 @@
     {
       "name": "Dremio",
       "url": "https://github.com/dremio/dremio-cloud-tools",
-      "ourLatest": "25.0.0"
+      "ourLatest": "20.1.0"
     },
     {
       "name": "TabbyML",


### PR DESCRIPTION
This change is due to Minio connection issue. Related to this [PR](https://github.com/devsentient/monorepo/pull/7412)