### PR TITLE
Update stack-component-versions.json

### DIFF
--- a/stack-component-versions.json
+++ b/stack-component-versions.json
@@ -70,7 +70,7 @@
     {
       "name": "Superset",
       "url": "https://github.com/apache/superset",
-      "ourLatest": "3.1.0"
+      "ourLatest": "4.1.2"
     },
     {
       "name": "Windmill",


### PR DESCRIPTION
chore: bump Superset from 3.0.1 to 4.1.2